### PR TITLE
Add FileIoManager interface documentation

### DIFF
--- a/AcornUiCore/src/com/acornui/file/FileIoManager.kt
+++ b/AcornUiCore/src/com/acornui/file/FileIoManager.kt
@@ -20,24 +20,53 @@ import com.acornui.core.Disposable
 import com.acornui.core.di.DKey
 import com.acornui.io.NativeBuffer
 
+/**
+ * An object which allows for selecting file(s) with native pickers for the purposes of reading or writing to disk.
+ *
+ * @see FileReader
+ * @see FileWriter
+ */
 interface FileIoManager : Disposable {
 
-	/**
-	 * If false, [pickFileForSave] will fail.
-	 */
+	/** If false, [pickFileForSave] will fail. */
 	val saveSupported: Boolean
 
+	/**
+	 * Invokes native file picker to select a file for opening from disk [onSuccess].
+	 * @param fileFilterGroups a list of groups of extensions to filter picking selection
+	 * @param onSuccess callback using a [FileWriter] to be executed upon a successful pick
+	 * @see FileFilterGroup
+	 */
 	fun pickFileForOpen(fileFilterGroups: List<FileFilterGroup>? = null, onSuccess: (FileReader) -> Unit)
+
+	/**
+	 * Invokes native file picker to select multiple files for opening from disk [onSuccess].
+	 * @param fileFilterGroups a list of groups of extensions to filter picking selection
+	 * @param onSuccess callback using a list of [FileWriter]s to be executed upon a successful pick
+	 * @see FileFilterGroup
+	 */
 	fun pickFilesForOpen(fileFilterGroups: List<FileFilterGroup>? = null, onSuccess: (List<FileReader>) -> Unit)
 
+	/**
+	 * Invokes native file picker to select an existing or new file for saving to disk [onSuccess].
+	 * @param fileFilterGroups a list of groups of extensions to filter picking selection
+	 * @param defaultExtension an extension to ensure is the suffix of the filename (e.g. 'filename' -> 'filename.txt')
+	 * @param onSuccess callback using a [FileWriter] to be executed upon a successful pick
+	 * @see FileFilterGroup
+	 */
 	fun pickFileForSave(fileFilterGroups: List<FileFilterGroup>? = null, defaultExtension: String? = null, onSuccess: (FileWriter) -> Unit)
 
 	companion object : DKey<FileIoManager>
 }
 
 /**
- * A list of extension groups to filter for when picking files.
- * @param extensions The list of extensions in this group.
+ * A list of [extensions] to filter for when picking files.
+ *
+ * An extension must *not* include the STOP character (e.g. ".txt", *not* "txt").
+ *
+ * For MAC and iOS (JVM and Safari), filtering defaults to all extensions due to underlying library limitations.
+ * For JS (sans Safari), all filter groups will be merged into a single filter group due to browser implementations.
+ * For JVM (sans MAC), each filter group will appear as a selection in the Options drop-down of the native picker.
  */
 class FileFilterGroup(
 		extensions: List<String>
@@ -45,22 +74,38 @@ class FileFilterGroup(
 	val extensions: List<String> = extensions.map { it.substringAfter(".").trim() }
 }
 
+/**
+ * An object that holds metadata properties for a picked file and allows for asynchronous reading of that file from disk.
+ */
 interface FileReader {
 
+	/** Name of the file including aboslute path (JS excludes path for security purposes) */
 	val name: String
+	/** Size of the file in bytes */
 	val size: Long
+	/** Last date the file was modified as the number of milliseconds since the Unix Epoch */
 	val lastModified: Long
 
+	/** Read file ([name]) from disk as a String */
 	suspend fun readAsString(): String
+	/** Read file ([name]) from disk binary */
 	suspend fun readAsBinary(): NativeBuffer<Byte>
 }
 
+/**
+ * An object that holds metadata properties for a picked file and allows for asynchronous writing of that file to disk.
+ */
 interface FileWriter {
 
+	/** Name of the file including absolute path */
 	val name: String
+	/** Size of the file in bytes */
 	val size: Long
+	/** Last date the file was modified as the number of milliseconds since the Unix Epoch */
 	val lastModified: Long
 
+	/** Write file ([name]) to disk as a String */
 	suspend fun saveToFileAsString(value: String)
+	/** Write file ([name]) to disk as binary */
 	suspend fun saveToFileAsBinary(value: NativeBuffer<Byte>)
 }


### PR DESCRIPTION
Hey can you look at this interface documentation and let me know if there are any big no-nos?
Also, some general guiding principles on what should be bothered to document for backend implementations.  I'm thinking documentation for private non-overriding functions (as necessary) would help ease refactoring and ensuring there are comments for business logic exceptions such as the comment for hiding the input element for iOS Safari or always returning an empty extension list for Safari/MAC JVM (I'm in favor of having those next to the code where the exceptions are being made instead of being double documented in things like member functions or class documentation for these parts of the api that are not exposed to core code).